### PR TITLE
Upddate sign in

### DIFF
--- a/apps/next/src/app/(app)/page.tsx
+++ b/apps/next/src/app/(app)/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { motion } from 'framer-motion'
 import CommandMenu from '~/components/CommandMenu'
+import AppBackground from '~/components/dashboard/AppBackground'
 import Footer from '~/components/Footer'
 import Header from '~/components/Header'
 import { SessionCompleteModal } from '~/components/SessionCompleteModal'
@@ -8,13 +9,8 @@ import GlobalSoundsPlayer from '~/components/helper/GlobalSoundsPlayer'
 import PrefetchUserTasks from '~/components/helper/PrefetchUserTasks'
 import Timer from '~/components/timer/Timer'
 import { TimerInitializer } from '~/components/timer/TimerInitializer'
-import { useTimerStore } from '~/store/useTimerStore'
 
 export default function Dashboard() {
-
-  const { currentSession, sessions } = useTimerStore()
-  console.log('Dashboard store state:', currentSession, sessions)
-
   return (
     <div>
       <GlobalSoundsPlayer />
@@ -22,7 +18,9 @@ export default function Dashboard() {
       <PrefetchUserTasks />
       <SessionCompleteModal />
       <CommandMenu />
-      <motion.main className='continer px-auto flex h-screen w-screen flex-col items-center justify-center'
+      <AppBackground />
+      <motion.main
+        className='continer px-auto relative z-10 flex h-screen w-screen flex-col items-center justify-center'
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ duration: 1, ease: 'easeOut', delay: 0.25 }}

--- a/apps/next/src/app/(auth)/sign-in/page.tsx
+++ b/apps/next/src/app/(auth)/sign-in/page.tsx
@@ -1,9 +1,8 @@
 'use client'
 
 import { motion } from 'framer-motion'
+import { useRouter } from 'next/navigation'
 import { signIn } from '~/lib/auth.client'
-
-const SUPREME = 'Supreme, ui-serif, Georgia, serif'
 
 const providers = [
   {
@@ -41,13 +40,11 @@ const providers = [
 const ease = [0.22, 1, 0.36, 1] as const
 
 export default function SignIn() {
+  const router = useRouter()
   const homePageUrl = `${process.env.NEXT_PUBLIC_APP_URL}/`
 
   return (
-    <div
-      className='relative min-h-screen w-full overflow-hidden bg-background text-foreground'
-      style={{ fontFamily: SUPREME }}
-    >
+    <div className='relative min-h-screen w-full overflow-hidden bg-background text-foreground'>
       {/* Grain overlay */}
       <svg
         aria-hidden
@@ -66,80 +63,39 @@ export default function SignIn() {
         className='pointer-events-none fixed inset-0 z-[0]'
         style={{
           background:
-            'radial-gradient(ellipse 60% 50% at 75% 40%, hsl(var(--accent) / 0.12), transparent 70%), radial-gradient(ellipse 50% 40% at 15% 90%, hsl(var(--muted) / 0.18), transparent 70%)',
+            'radial-gradient(ellipse 60% 50% at 75% 40%, hsl(var(--accent) / 0.10), transparent 70%), radial-gradient(ellipse 50% 40% at 15% 90%, hsl(var(--muted) / 0.14), transparent 70%)',
         }}
       />
 
-      {/* Watermark numeral */}
-      <motion.div
-        aria-hidden
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ duration: 1.6, ease, delay: 0.6 }}
-        className='pointer-events-none absolute -bottom-12 -right-6 z-[1] select-none leading-none'
-        style={{
-          fontFamily: SUPREME,
-          fontWeight: 200,
-          fontStyle: 'italic',
-          fontSize: 'clamp(14rem, 28vw, 30rem)',
-          color: 'hsl(var(--foreground) / 0.04)',
-          letterSpacing: '-0.04em',
-        }}
-      >
-        25
-      </motion.div>
-
-      {/* Vertical sidebar label */}
-      <div
-        className='absolute left-6 top-1/2 z-[2] hidden -translate-y-1/2 -rotate-90 origin-left text-[10px] uppercase tracking-[0.4em] text-muted-foreground md:block'
-        style={{ fontFamily: SUPREME, fontWeight: 500 }}
-      >
-        Vol. 01 — A Focus Almanac
-      </div>
-
-      {/* Top bar */}
+      {/* Top bar — single anchor */}
       <header className='relative z-[3] flex items-center justify-between px-8 pt-8 md:px-16 md:pt-10'>
         <motion.div
           initial={{ opacity: 0, y: -8 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.7, ease }}
-          className='flex items-center gap-3 text-[11px] uppercase tracking-[0.32em] text-muted-foreground'
-          style={{ fontFamily: SUPREME, fontWeight: 500 }}
+          className='flex items-center gap-3 text-[11px] font-medium uppercase tracking-[0.32em] text-muted-foreground'
         >
           <span className='inline-block h-[6px] w-[6px] rounded-full bg-foreground' />
           Be Focus
         </motion.div>
-        <motion.div
-          initial={{ opacity: 0, y: -8 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.7, ease, delay: 0.05 }}
-          className='text-[11px] uppercase tracking-[0.32em] text-muted-foreground'
-          style={{ fontFamily: SUPREME, fontWeight: 500 }}
-        >
-          Est. 2025
-        </motion.div>
       </header>
 
       {/* Main composition */}
-      <main className='relative z-[3] mx-auto grid min-h-[calc(100vh-12rem)] max-w-7xl grid-cols-1 items-center gap-16 px-8 py-16 md:grid-cols-12 md:gap-8 md:px-16'>
+      <main className='relative z-[3] mx-auto grid min-h-[calc(100vh-8rem)] max-w-7xl grid-cols-1 items-center gap-16 px-8 py-16 md:grid-cols-12 md:gap-12 md:px-16'>
         {/* Editorial column */}
         <section className='md:col-span-7'>
           <motion.p
             initial={{ opacity: 0, y: 8 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6, ease, delay: 0.15 }}
-            className='mb-8 text-[11px] uppercase tracking-[0.4em] text-muted-foreground'
-            style={{ fontFamily: SUPREME, fontWeight: 500 }}
+            className='mb-8 text-[11px] font-medium uppercase tracking-[0.4em] text-muted-foreground'
           >
             Session — 01 / Sign in
           </motion.p>
 
           <h1
-            className='leading-[0.92] tracking-[-0.04em]'
-            style={{
-              fontFamily: SUPREME,
-              fontSize: 'clamp(3.5rem, 9vw, 8rem)',
-            }}
+            className='font-display leading-[0.92] tracking-[-0.04em]'
+            style={{ fontSize: 'clamp(3.5rem, 9vw, 8rem)' }}
           >
             {['Quiet', 'focus,', 'deep', 'work.'].map((word, i) => (
               <motion.span
@@ -162,8 +118,7 @@ export default function SignIn() {
             initial={{ opacity: 0, y: 8 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.7, ease, delay: 0.7 }}
-            className='mt-10 max-w-md text-base leading-relaxed text-muted-foreground md:text-lg'
-            style={{ fontFamily: SUPREME, fontWeight: 300 }}
+            className='mt-10 max-w-md text-base font-light leading-relaxed text-muted-foreground md:text-lg'
           >
             A simple ritual — twenty-five minutes at a time. Sign in to keep your sessions, sounds, and tasks in sync wherever you are.
           </motion.p>
@@ -171,45 +126,45 @@ export default function SignIn() {
 
         {/* Sign-in column */}
         <aside className='relative md:col-span-5'>
-          {/* Decorative timer ring */}
+          {/* Decorative timer ring — smaller, quieter */}
           <motion.div
             initial={{ opacity: 0, scale: 0.85 }}
             animate={{ opacity: 1, scale: 1 }}
             transition={{ duration: 1.2, ease, delay: 0.4 }}
-            className='pointer-events-none absolute -right-24 -top-24 hidden md:block'
+            className='pointer-events-none absolute -right-16 -top-20 hidden md:block'
             aria-hidden
           >
             <motion.svg
-              width='340'
-              height='340'
-              viewBox='0 0 340 340'
+              width='240'
+              height='240'
+              viewBox='0 0 240 240'
               animate={{ rotate: 360 }}
-              transition={{ duration: 120, ease: 'linear', repeat: Number.POSITIVE_INFINITY }}
+              transition={{ duration: 180, ease: 'linear', repeat: Number.POSITIVE_INFINITY }}
             >
               <circle
-                cx='170'
-                cy='170'
-                r='160'
+                cx='120'
+                cy='120'
+                r='112'
                 fill='none'
-                stroke='hsl(var(--foreground) / 0.12)'
+                stroke='hsl(var(--foreground) / 0.08)'
                 strokeWidth='1'
               />
               <circle
-                cx='170'
-                cy='170'
-                r='160'
+                cx='120'
+                cy='120'
+                r='112'
                 fill='none'
-                stroke='hsl(var(--foreground) / 0.6)'
+                stroke='hsl(var(--foreground) / 0.35)'
                 strokeWidth='1'
-                strokeDasharray='2 14'
+                strokeDasharray='1.5 12'
                 strokeLinecap='round'
               />
               {Array.from({ length: 12 }).map((_, i) => {
                 const angle = (i / 12) * Math.PI * 2 - Math.PI / 2
-                const x1 = 170 + Math.cos(angle) * 148
-                const y1 = 170 + Math.sin(angle) * 148
-                const x2 = 170 + Math.cos(angle) * (i % 3 === 0 ? 132 : 142)
-                const y2 = 170 + Math.sin(angle) * (i % 3 === 0 ? 132 : 142)
+                const x1 = 120 + Math.cos(angle) * 102
+                const y1 = 120 + Math.sin(angle) * 102
+                const x2 = 120 + Math.cos(angle) * (i % 3 === 0 ? 90 : 96)
+                const y2 = 120 + Math.sin(angle) * (i % 3 === 0 ? 90 : 96)
                 return (
                   <line
                     key={i}
@@ -217,8 +172,8 @@ export default function SignIn() {
                     y1={y1}
                     x2={x2}
                     y2={y2}
-                    stroke='hsl(var(--foreground) / 0.45)'
-                    strokeWidth={i % 3 === 0 ? 1.2 : 0.8}
+                    stroke='hsl(var(--foreground) / 0.30)'
+                    strokeWidth={i % 3 === 0 ? 1 : 0.7}
                     strokeLinecap='round'
                   />
                 )
@@ -232,20 +187,12 @@ export default function SignIn() {
             transition={{ duration: 0.9, ease, delay: 0.55 }}
             className='relative overflow-hidden rounded-2xl border border-border/60 bg-card/70 backdrop-blur-md shadow-[0_30px_80px_-30px_rgba(0,0,0,0.45)]'
           >
-            {/* Inner divider header */}
+            {/* Header */}
             <div className='flex items-center justify-between border-b border-border/50 px-6 py-5'>
-              <span
-                className='text-[10px] uppercase tracking-[0.36em] text-muted-foreground'
-                style={{ fontFamily: SUPREME, fontWeight: 500 }}
-              >
+              <span className='text-[10px] font-medium uppercase tracking-[0.36em] text-muted-foreground'>
                 Begin Session
               </span>
-              <span
-                className='text-[10px] tabular-nums text-muted-foreground'
-                style={{ fontFamily: SUPREME, fontWeight: 400 }}
-              >
-                25 : 00
-              </span>
+              <span className='text-[10px] tabular-nums text-muted-foreground'>25 : 00</span>
             </div>
 
             {/* Provider rows */}
@@ -261,22 +208,16 @@ export default function SignIn() {
                     type='button'
                     onClick={() => signIn.social({ provider: p.id, callbackURL: homePageUrl })}
                     className='group flex w-full items-center justify-between px-6 py-5 text-left transition-colors hover:bg-accent/40 focus-visible:bg-accent/40 focus-visible:outline-none'
-                    style={{ fontFamily: SUPREME }}
                   >
                     <span className='flex items-center gap-4'>
                       <span className='flex h-8 w-8 items-center justify-center rounded-full bg-foreground/5 text-foreground transition-colors group-hover:bg-foreground/10'>
                         {p.icon}
                       </span>
                       <span className='flex flex-col'>
-                        <span
-                          className='text-[10px] uppercase tracking-[0.32em] text-muted-foreground'
-                          style={{ fontWeight: 500 }}
-                        >
+                        <span className='text-[10px] font-medium uppercase tracking-[0.32em] text-muted-foreground'>
                           Continue with
                         </span>
-                        <span className='text-base text-foreground' style={{ fontWeight: 500 }}>
-                          {p.label}
-                        </span>
+                        <span className='text-base font-medium text-foreground'>{p.label}</span>
                       </span>
                     </span>
                     <span
@@ -298,45 +239,39 @@ export default function SignIn() {
               ))}
             </ul>
 
-            {/* Footer caption */}
+            {/* Guest escape hatch */}
             <motion.div
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
-              transition={{ duration: 0.7, ease, delay: 1.05 }}
-              className='border-t border-border/50 px-6 py-4'
+              transition={{ duration: 0.7, ease, delay: 1.0 }}
+              className='border-t border-border/50'
             >
-              <p
-                className='text-[11px] leading-relaxed text-muted-foreground'
-                style={{ fontFamily: SUPREME, fontWeight: 300 }}
+              <button
+                type='button'
+                onClick={() => router.push('/guest')}
+                className='group flex w-full items-center justify-between px-6 py-4 text-left transition-colors hover:bg-accent/30 focus-visible:bg-accent/30 focus-visible:outline-none'
               >
-                Your sessions and preferences sync across devices. No password to remember.
-              </p>
+                <span className='flex flex-col'>
+                  <span className='text-[10px] font-medium uppercase tracking-[0.32em] text-muted-foreground'>
+                    No account?
+                  </span>
+                  <span className='text-sm text-foreground/80 transition-colors group-hover:text-foreground'>
+                    Continue as guest
+                  </span>
+                </span>
+                <span
+                  className='text-foreground/40 transition-all group-hover:translate-x-1 group-hover:text-foreground/80'
+                  aria-hidden
+                >
+                  <svg width='18' height='10' viewBox='0 0 22 10' fill='none' xmlns='http://www.w3.org/2000/svg'>
+                    <path d='M1 5h19M16 1l4 4-4 4' stroke='currentColor' strokeWidth='1.2' strokeLinecap='round' strokeLinejoin='round' />
+                  </svg>
+                </span>
+              </button>
             </motion.div>
           </motion.div>
         </aside>
       </main>
-
-      {/* Footer */}
-      <footer className='relative z-[3] flex items-end justify-between px-8 pb-8 md:px-16 md:pb-10'>
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ duration: 0.7, ease, delay: 1.2 }}
-          className='text-[11px] uppercase tracking-[0.32em] text-muted-foreground'
-          style={{ fontFamily: SUPREME, fontWeight: 500 }}
-        >
-          New session — Pomodoro 25 ⁄ 5
-        </motion.div>
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ duration: 0.7, ease, delay: 1.25 }}
-          className='hidden text-[11px] uppercase tracking-[0.32em] text-muted-foreground md:block'
-          style={{ fontFamily: SUPREME, fontWeight: 500 }}
-        >
-          ↳ Sign in to begin
-        </motion.div>
-      </footer>
     </div>
   )
 }

--- a/apps/next/src/app/(auth)/sign-in/page.tsx
+++ b/apps/next/src/app/(auth)/sign-in/page.tsx
@@ -1,85 +1,342 @@
 'use client'
-import { Button } from '@repo/ui/button'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@repo/ui/card'
-import Image from 'next/image'
+
+import { motion } from 'framer-motion'
 import { signIn } from '~/lib/auth.client'
+
+const SUPREME = 'Supreme, ui-serif, Georgia, serif'
+
+const providers = [
+  {
+    id: 'github' as const,
+    label: 'GitHub',
+    icon: (
+      <svg viewBox='0 0 24 24' className='h-[18px] w-[18px]' fill='currentColor' aria-hidden>
+        <path d='M12 .5C5.65.5.5 5.65.5 12.02c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.34-1.28-1.69-1.28-1.69-1.05-.72.08-.71.08-.71 1.16.08 1.78 1.2 1.78 1.2 1.04 1.78 2.72 1.27 3.39.97.1-.75.4-1.27.74-1.56-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.09-.12-.29-.51-1.46.11-3.05 0 0 .96-.31 3.15 1.18a10.95 10.95 0 0 1 5.74 0c2.19-1.49 3.15-1.18 3.15-1.18.62 1.59.23 2.76.11 3.05.74.8 1.18 1.83 1.18 3.09 0 4.42-2.69 5.39-5.26 5.68.41.36.78 1.06.78 2.14v3.17c0 .31.21.68.8.56 4.56-1.52 7.85-5.83 7.85-10.91C23.5 5.65 18.35.5 12 .5z' />
+      </svg>
+    ),
+  },
+  {
+    id: 'google' as const,
+    label: 'Google',
+    icon: (
+      <svg viewBox='0 0 24 24' className='h-[18px] w-[18px]' aria-hidden>
+        <path
+          fill='#EA4335'
+          d='M12 10.2v3.9h5.5c-.24 1.45-1.7 4.25-5.5 4.25-3.31 0-6.01-2.74-6.01-6.12s2.7-6.12 6.01-6.12c1.88 0 3.14.8 3.86 1.49l2.63-2.53C16.83 3.6 14.6 2.6 12 2.6 6.86 2.6 2.7 6.76 2.7 11.9S6.86 21.2 12 21.2c6.93 0 9.3-4.86 9.3-7.97 0-.54-.06-.96-.13-1.37H12z'
+        />
+      </svg>
+    ),
+  },
+  {
+    id: 'discord' as const,
+    label: 'Discord',
+    icon: (
+      <svg viewBox='0 0 24 24' className='h-[18px] w-[18px]' fill='currentColor' aria-hidden>
+        <path d='M20.317 4.369A19.79 19.79 0 0 0 16.558 3a14.45 14.45 0 0 0-.706 1.45 18.27 18.27 0 0 0-5.486 0A14.46 14.46 0 0 0 9.66 3a19.74 19.74 0 0 0-3.762 1.37C2.79 9.046 1.95 13.58 2.37 18.05a19.9 19.9 0 0 0 6.073 3.07c.49-.67.927-1.39 1.302-2.144a13 13 0 0 1-2.052-.984c.172-.127.34-.26.503-.397 3.95 1.83 8.224 1.83 12.124 0 .165.137.333.27.504.397a13 13 0 0 1-2.057.987c.376.752.812 1.473 1.302 2.143a19.87 19.87 0 0 0 6.077-3.07c.493-5.183-.838-9.677-3.83-13.683zM9.545 15.413c-1.21 0-2.21-1.117-2.21-2.488s.978-2.49 2.21-2.49c1.232 0 2.231 1.118 2.21 2.49 0 1.371-.978 2.488-2.21 2.488zm4.91 0c-1.21 0-2.21-1.117-2.21-2.488s.979-2.49 2.21-2.49c1.231 0 2.231 1.118 2.21 2.49 0 1.371-.979 2.488-2.21 2.488z' />
+      </svg>
+    ),
+  },
+] as const
+
+const ease = [0.22, 1, 0.36, 1] as const
 
 export default function SignIn() {
   const homePageUrl = `${process.env.NEXT_PUBLIC_APP_URL}/`
 
   return (
-    <div className='min-h-screen flex items-center justify-center p-4'>
-      <div className='w-full max-w-md'>
-        <Card>
-          <CardHeader className='text-center'>
-            <CardTitle className='text-2xl'>Welcome to Be Focus</CardTitle>
-            <CardDescription>
-              Sign in to continue to your dashboard
-            </CardDescription>
-          </CardHeader>
+    <div
+      className='relative min-h-screen w-full overflow-hidden bg-background text-foreground'
+      style={{ fontFamily: SUPREME }}
+    >
+      {/* Grain overlay */}
+      <svg
+        aria-hidden
+        className='pointer-events-none fixed inset-0 z-[1] h-full w-full opacity-[0.06] mix-blend-overlay'
+      >
+        <filter id='grain'>
+          <feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch' />
+          <feColorMatrix type='saturate' values='0' />
+        </filter>
+        <rect width='100%' height='100%' filter='url(#grain)' />
+      </svg>
 
-          <CardContent className='space-y-4 '>
-            <Button
-              variant='outline'
-              className='flex items-center justify-center gap-3 w-full h-11'
-              onClick={() => signIn.social({ provider: 'github', callbackURL: homePageUrl })}
-            >
-              <Image
-                alt='GitHub'
-                src='https://www.cdnlogo.com/logos/g/69/github-icon.svg'
-                width={18}
-                height={18}
-                className="dark:border dark:border-white dark:rounded-3xl dark:bg-white"
-              />
-              Continue with GitHub
-            </Button>
+      {/* Soft radial atmosphere */}
+      <div
+        aria-hidden
+        className='pointer-events-none fixed inset-0 z-[0]'
+        style={{
+          background:
+            'radial-gradient(ellipse 60% 50% at 75% 40%, hsl(var(--accent) / 0.12), transparent 70%), radial-gradient(ellipse 50% 40% at 15% 90%, hsl(var(--muted) / 0.18), transparent 70%)',
+        }}
+      />
 
-            <Button
-              variant='outline'
-              className='flex items-center justify-center gap-3 w-full h-11'
-              onClick={() =>
-                signIn.social({
-                  provider: 'google',
-                  callbackURL: homePageUrl,
-                })
-              }
-            >
-              <Image
-                alt='Google'
-                src='https://www.cdnlogo.com/logos/g/35/google-icon.svg'
-                width={18}
-                height={18}
-              />
-              Continue with Google
-            </Button>
+      {/* Watermark numeral */}
+      <motion.div
+        aria-hidden
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 1.6, ease, delay: 0.6 }}
+        className='pointer-events-none absolute -bottom-12 -right-6 z-[1] select-none leading-none'
+        style={{
+          fontFamily: SUPREME,
+          fontWeight: 200,
+          fontStyle: 'italic',
+          fontSize: 'clamp(14rem, 28vw, 30rem)',
+          color: 'hsl(var(--foreground) / 0.04)',
+          letterSpacing: '-0.04em',
+        }}
+      >
+        25
+      </motion.div>
 
-            <Button
-              variant='outline'
-              className='flex items-center justify-center gap-3 w-full h-11'
-              onClick={() =>
-                signIn.social({
-                  provider: 'discord',
-                  callbackURL: homePageUrl,
-                })
-              }
-            >
-              <Image
-                alt='Discord'
-                src='https://static.cdnlogo.com/logos/d/15/discord.svg'
-                width={18}
-                height={18}
-              />
-              Continue with Discord
-            </Button>
-
-            <div className='pt-4 border-t'>
-              <p className='text-xs text-muted-foreground text-center'>
-                Sign in to access your personalized focus dashboard
-              </p>
-            </div>
-          </CardContent>
-        </Card>
+      {/* Vertical sidebar label */}
+      <div
+        className='absolute left-6 top-1/2 z-[2] hidden -translate-y-1/2 -rotate-90 origin-left text-[10px] uppercase tracking-[0.4em] text-muted-foreground md:block'
+        style={{ fontFamily: SUPREME, fontWeight: 500 }}
+      >
+        Vol. 01 — A Focus Almanac
       </div>
+
+      {/* Top bar */}
+      <header className='relative z-[3] flex items-center justify-between px-8 pt-8 md:px-16 md:pt-10'>
+        <motion.div
+          initial={{ opacity: 0, y: -8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.7, ease }}
+          className='flex items-center gap-3 text-[11px] uppercase tracking-[0.32em] text-muted-foreground'
+          style={{ fontFamily: SUPREME, fontWeight: 500 }}
+        >
+          <span className='inline-block h-[6px] w-[6px] rounded-full bg-foreground' />
+          Be Focus
+        </motion.div>
+        <motion.div
+          initial={{ opacity: 0, y: -8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.7, ease, delay: 0.05 }}
+          className='text-[11px] uppercase tracking-[0.32em] text-muted-foreground'
+          style={{ fontFamily: SUPREME, fontWeight: 500 }}
+        >
+          Est. 2025
+        </motion.div>
+      </header>
+
+      {/* Main composition */}
+      <main className='relative z-[3] mx-auto grid min-h-[calc(100vh-12rem)] max-w-7xl grid-cols-1 items-center gap-16 px-8 py-16 md:grid-cols-12 md:gap-8 md:px-16'>
+        {/* Editorial column */}
+        <section className='md:col-span-7'>
+          <motion.p
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, ease, delay: 0.15 }}
+            className='mb-8 text-[11px] uppercase tracking-[0.4em] text-muted-foreground'
+            style={{ fontFamily: SUPREME, fontWeight: 500 }}
+          >
+            Session — 01 / Sign in
+          </motion.p>
+
+          <h1
+            className='leading-[0.92] tracking-[-0.04em]'
+            style={{
+              fontFamily: SUPREME,
+              fontSize: 'clamp(3.5rem, 9vw, 8rem)',
+            }}
+          >
+            {['Quiet', 'focus,', 'deep', 'work.'].map((word, i) => (
+              <motion.span
+                key={word}
+                initial={{ opacity: 0, y: 24, filter: 'blur(8px)' }}
+                animate={{ opacity: 1, y: 0, filter: 'blur(0px)' }}
+                transition={{ duration: 0.9, ease, delay: 0.25 + i * 0.08 }}
+                className='block'
+                style={{
+                  fontWeight: i === 1 ? 200 : 400,
+                  fontStyle: i === 1 ? 'italic' : 'normal',
+                }}
+              >
+                {word}
+              </motion.span>
+            ))}
+          </h1>
+
+          <motion.p
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.7, ease, delay: 0.7 }}
+            className='mt-10 max-w-md text-base leading-relaxed text-muted-foreground md:text-lg'
+            style={{ fontFamily: SUPREME, fontWeight: 300 }}
+          >
+            A simple ritual — twenty-five minutes at a time. Sign in to keep your sessions, sounds, and tasks in sync wherever you are.
+          </motion.p>
+        </section>
+
+        {/* Sign-in column */}
+        <aside className='relative md:col-span-5'>
+          {/* Decorative timer ring */}
+          <motion.div
+            initial={{ opacity: 0, scale: 0.85 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ duration: 1.2, ease, delay: 0.4 }}
+            className='pointer-events-none absolute -right-24 -top-24 hidden md:block'
+            aria-hidden
+          >
+            <motion.svg
+              width='340'
+              height='340'
+              viewBox='0 0 340 340'
+              animate={{ rotate: 360 }}
+              transition={{ duration: 120, ease: 'linear', repeat: Number.POSITIVE_INFINITY }}
+            >
+              <circle
+                cx='170'
+                cy='170'
+                r='160'
+                fill='none'
+                stroke='hsl(var(--foreground) / 0.12)'
+                strokeWidth='1'
+              />
+              <circle
+                cx='170'
+                cy='170'
+                r='160'
+                fill='none'
+                stroke='hsl(var(--foreground) / 0.6)'
+                strokeWidth='1'
+                strokeDasharray='2 14'
+                strokeLinecap='round'
+              />
+              {Array.from({ length: 12 }).map((_, i) => {
+                const angle = (i / 12) * Math.PI * 2 - Math.PI / 2
+                const x1 = 170 + Math.cos(angle) * 148
+                const y1 = 170 + Math.sin(angle) * 148
+                const x2 = 170 + Math.cos(angle) * (i % 3 === 0 ? 132 : 142)
+                const y2 = 170 + Math.sin(angle) * (i % 3 === 0 ? 132 : 142)
+                return (
+                  <line
+                    key={i}
+                    x1={x1}
+                    y1={y1}
+                    x2={x2}
+                    y2={y2}
+                    stroke='hsl(var(--foreground) / 0.45)'
+                    strokeWidth={i % 3 === 0 ? 1.2 : 0.8}
+                    strokeLinecap='round'
+                  />
+                )
+              })}
+            </motion.svg>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, y: 24 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.9, ease, delay: 0.55 }}
+            className='relative overflow-hidden rounded-2xl border border-border/60 bg-card/70 backdrop-blur-md shadow-[0_30px_80px_-30px_rgba(0,0,0,0.45)]'
+          >
+            {/* Inner divider header */}
+            <div className='flex items-center justify-between border-b border-border/50 px-6 py-5'>
+              <span
+                className='text-[10px] uppercase tracking-[0.36em] text-muted-foreground'
+                style={{ fontFamily: SUPREME, fontWeight: 500 }}
+              >
+                Begin Session
+              </span>
+              <span
+                className='text-[10px] tabular-nums text-muted-foreground'
+                style={{ fontFamily: SUPREME, fontWeight: 400 }}
+              >
+                25 : 00
+              </span>
+            </div>
+
+            {/* Provider rows */}
+            <ul className='divide-y divide-border/50'>
+              {providers.map((p, i) => (
+                <motion.li
+                  key={p.id}
+                  initial={{ opacity: 0, x: 12 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  transition={{ duration: 0.6, ease, delay: 0.75 + i * 0.07 }}
+                >
+                  <button
+                    type='button'
+                    onClick={() => signIn.social({ provider: p.id, callbackURL: homePageUrl })}
+                    className='group flex w-full items-center justify-between px-6 py-5 text-left transition-colors hover:bg-accent/40 focus-visible:bg-accent/40 focus-visible:outline-none'
+                    style={{ fontFamily: SUPREME }}
+                  >
+                    <span className='flex items-center gap-4'>
+                      <span className='flex h-8 w-8 items-center justify-center rounded-full bg-foreground/5 text-foreground transition-colors group-hover:bg-foreground/10'>
+                        {p.icon}
+                      </span>
+                      <span className='flex flex-col'>
+                        <span
+                          className='text-[10px] uppercase tracking-[0.32em] text-muted-foreground'
+                          style={{ fontWeight: 500 }}
+                        >
+                          Continue with
+                        </span>
+                        <span className='text-base text-foreground' style={{ fontWeight: 500 }}>
+                          {p.label}
+                        </span>
+                      </span>
+                    </span>
+                    <span
+                      className='translate-x-0 text-foreground/60 transition-all group-hover:translate-x-1 group-hover:text-foreground'
+                      aria-hidden
+                    >
+                      <svg
+                        width='22'
+                        height='10'
+                        viewBox='0 0 22 10'
+                        fill='none'
+                        xmlns='http://www.w3.org/2000/svg'
+                      >
+                        <path d='M1 5h19M16 1l4 4-4 4' stroke='currentColor' strokeWidth='1.2' strokeLinecap='round' strokeLinejoin='round' />
+                      </svg>
+                    </span>
+                  </button>
+                </motion.li>
+              ))}
+            </ul>
+
+            {/* Footer caption */}
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ duration: 0.7, ease, delay: 1.05 }}
+              className='border-t border-border/50 px-6 py-4'
+            >
+              <p
+                className='text-[11px] leading-relaxed text-muted-foreground'
+                style={{ fontFamily: SUPREME, fontWeight: 300 }}
+              >
+                Your sessions and preferences sync across devices. No password to remember.
+              </p>
+            </motion.div>
+          </motion.div>
+        </aside>
+      </main>
+
+      {/* Footer */}
+      <footer className='relative z-[3] flex items-end justify-between px-8 pb-8 md:px-16 md:pb-10'>
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.7, ease, delay: 1.2 }}
+          className='text-[11px] uppercase tracking-[0.32em] text-muted-foreground'
+          style={{ fontFamily: SUPREME, fontWeight: 500 }}
+        >
+          New session — Pomodoro 25 ⁄ 5
+        </motion.div>
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.7, ease, delay: 1.25 }}
+          className='hidden text-[11px] uppercase tracking-[0.32em] text-muted-foreground md:block'
+          style={{ fontFamily: SUPREME, fontWeight: 500 }}
+        >
+          ↳ Sign in to begin
+        </motion.div>
+      </footer>
     </div>
   )
 }

--- a/apps/next/src/app/guest/page.tsx
+++ b/apps/next/src/app/guest/page.tsx
@@ -3,7 +3,7 @@
 import { AnimatePresence, motion } from 'framer-motion'
 import dynamic from 'next/dynamic'
 import { useEffect, useState } from 'react'
-// import CommandMenu from '~/components/CommandMenu'
+import AppBackground from '~/components/dashboard/AppBackground'
 import Footer from '~/components/Footer'
 import Header from '~/components/Header'
 import { SessionCompleteModal } from '~/components/SessionCompleteModal'
@@ -13,8 +13,6 @@ import Timer from '~/components/timer/Timer'
 const INTRO_FLAG = 'befocus.guestIntroShown'
 
 export default function App() {
-  // TODO: update use of useSession with useQueryClient
-
   const CommandMenu = dynamic(() => import('~/components/CommandMenu'), { ssr: false })
 
   const [showIntro, setShowIntro] = useState(false)
@@ -39,6 +37,7 @@ export default function App() {
       <GlobalSoundsPlayer />
       <SessionCompleteModal />
       <CommandMenu />
+      <AppBackground />
 
       <AnimatePresence onExitComplete={() => setIntroDone(true)}>
         {showIntro && (
@@ -64,7 +63,7 @@ export default function App() {
 
       {introDone && (
         <motion.main
-          className='continer px-auto flex h-screen w-screen flex-col items-center justify-center'
+          className='continer px-auto relative z-10 flex h-screen w-screen flex-col items-center justify-center'
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ duration: 1, ease: 'easeOut', delay: 0.25 }}

--- a/apps/next/src/app/layout.tsx
+++ b/apps/next/src/app/layout.tsx
@@ -2,6 +2,9 @@ import '@repo/ui/globals.css'
 import ThemeProvider from '~/components/sessions/ThemeProvider'
 import AppProviders from '~/provider/AppProviders'
 
+const FONTS_URL =
+  'https://fonts.googleapis.com/css2?family=Inter+Tight:ital,wght@0,200..900;1,200..900&display=swap'
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -9,11 +12,16 @@ export default function RootLayout({
 }>) {
   return (
     <html lang='en' className='dark' suppressHydrationWarning>
-        <body suppressHydrationWarning>
-          <ThemeProvider attribute='class' defaultTheme='dark' enableSystem>
-            <AppProviders>{children}</AppProviders>
-          </ThemeProvider>
-        </body>
+      <head>
+        <link rel='preconnect' href='https://fonts.googleapis.com' />
+        <link rel='preconnect' href='https://fonts.gstatic.com' crossOrigin='' />
+        <link rel='stylesheet' href={FONTS_URL} />
+      </head>
+      <body suppressHydrationWarning>
+        <ThemeProvider attribute='class' defaultTheme='dark' enableSystem>
+          <AppProviders>{children}</AppProviders>
+        </ThemeProvider>
+      </body>
     </html>
   )
 }

--- a/apps/next/src/components/dashboard/AppBackground.tsx
+++ b/apps/next/src/components/dashboard/AppBackground.tsx
@@ -1,0 +1,51 @@
+export default function AppBackground() {
+  return (
+    <>
+      {/* Solid theme background */}
+      <div aria-hidden className='pointer-events-none fixed inset-0 z-0 bg-background' />
+
+      {/* User-customizable image (settings page will populate via CSS vars) */}
+      <div
+        aria-hidden
+        className='pointer-events-none fixed inset-0 z-0'
+        style={{
+          backgroundImage: 'var(--bg-image)',
+          backgroundSize: 'var(--bg-image-size)',
+          backgroundPosition: 'var(--bg-image-position)',
+          filter: 'blur(var(--bg-blur))',
+        }}
+      />
+
+      {/* User-customizable overlay tint */}
+      <div
+        aria-hidden
+        className='pointer-events-none fixed inset-0 z-0'
+        style={{
+          backgroundColor: 'hsl(var(--bg-overlay-color) / var(--bg-overlay-opacity))',
+        }}
+      />
+
+      {/* Soft radial atmosphere */}
+      <div
+        aria-hidden
+        className='pointer-events-none fixed inset-0 z-0'
+        style={{
+          background:
+            'radial-gradient(ellipse 60% 50% at 75% 30%, hsl(var(--accent) / 0.10), transparent 70%), radial-gradient(ellipse 50% 40% at 15% 90%, hsl(var(--muted) / 0.14), transparent 70%)',
+        }}
+      />
+
+      {/* Grain */}
+      <svg
+        aria-hidden
+        className='pointer-events-none fixed inset-0 z-0 h-full w-full opacity-[0.05] mix-blend-overlay'
+      >
+        <filter id='app-grain'>
+          <feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch' />
+          <feColorMatrix type='saturate' values='0' />
+        </filter>
+        <rect width='100%' height='100%' filter='url(#app-grain)' />
+      </svg>
+    </>
+  )
+}

--- a/apps/next/src/components/dashboard/TimerProgressRing.tsx
+++ b/apps/next/src/components/dashboard/TimerProgressRing.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { useTimerStore } from '~/store/useTimerStore'
+
+const VIEWBOX = 800
+const CENTER = VIEWBOX / 2
+const RADIUS = 380
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS
+
+export default function TimerProgressRing() {
+  const timeLeft = useTimerStore(s => s.timeLeft)
+  const workDuration = useTimerStore(s => s.workDuration)
+  const breakDuration = useTimerStore(s => s.breakDuration)
+  const isWorking = useTimerStore(s => s.isWorking)
+
+  const total = isWorking ? workDuration : breakDuration
+  const elapsed = total > 0 ? Math.min(1, Math.max(0, 1 - timeLeft / total)) : 0
+  const offset = CIRCUMFERENCE * elapsed
+
+  return (
+    <div
+      aria-hidden
+      className='pointer-events-none absolute inset-0 flex items-center justify-center'
+    >
+      <svg
+        viewBox={`0 0 ${VIEWBOX} ${VIEWBOX}`}
+        className='-rotate-90 h-[min(72vh,92vw)] w-[min(72vh,92vw)]'
+      >
+        <circle
+          cx={CENTER}
+          cy={CENTER}
+          r={RADIUS}
+          fill='none'
+          stroke='hsl(var(--foreground) / 0.05)'
+          strokeWidth='1'
+        />
+        <circle
+          cx={CENTER}
+          cy={CENTER}
+          r={RADIUS}
+          fill='none'
+          stroke='hsl(var(--foreground) / 0.15)'
+          strokeWidth='1'
+          strokeDasharray='1.5 14'
+          strokeLinecap='round'
+        />
+        <circle
+          cx={CENTER}
+          cy={CENTER}
+          r={RADIUS}
+          fill='none'
+          stroke='hsl(var(--foreground) / 0.5)'
+          strokeWidth='1.5'
+          strokeDasharray={CIRCUMFERENCE}
+          strokeDashoffset={CIRCUMFERENCE - offset}
+          strokeLinecap='round'
+          style={{ transition: 'stroke-dashoffset 1s linear' }}
+        />
+        {Array.from({ length: 12 }).map((_, i) => {
+          const angle = (i / 12) * Math.PI * 2
+          const major = i % 3 === 0
+          const inner = RADIUS - (major ? 26 : 14)
+          const x1 = CENTER + Math.cos(angle) * RADIUS
+          const y1 = CENTER + Math.sin(angle) * RADIUS
+          const x2 = CENTER + Math.cos(angle) * inner
+          const y2 = CENTER + Math.sin(angle) * inner
+          return (
+            <line
+              key={i}
+              x1={x1}
+              y1={y1}
+              x2={x2}
+              y2={y2}
+              stroke={`hsl(var(--foreground) / ${major ? 0.3 : 0.15})`}
+              strokeWidth={major ? 1.2 : 0.7}
+              strokeLinecap='round'
+            />
+          )
+        })}
+      </svg>
+    </div>
+  )
+}

--- a/apps/next/src/components/sessions/SessionTitleDisplay.tsx
+++ b/apps/next/src/components/sessions/SessionTitleDisplay.tsx
@@ -13,20 +13,20 @@ export default function SessionTitleDisplay() {
       : 'Break'
     : workDuration === timeLeft
       ? 'Be Focus'
-      : isWorking
-        ? 'Paused'
-        : 'Break'
+      : 'Paused'
 
   const isLandscape = useIsLandscape()
+  const isIdle = !isRunning
 
   return (
     <AnimatePresence mode='wait'>
       <motion.p
-        key={text} // Forces re-render when text changes
-        animate={{ opacity: 1, y: 0 }} // Fades in and moves into place
-        exit={{ opacity: 0, y: 0 }} // Moves up slightly when fading out
+        key={text}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: 0 }}
         transition={{ duration: 0.25, ease: 'easeInOut' }}
-        className={`text-right text-4xl font-bold ${isLandscape ? 'pt-10 sm:text-4xl' : 'sm:text-5xl'} lg:text-7xl`}
+        className={`text-right text-4xl tracking-tight ${isIdle ? 'font-bold italic text-foreground/85' : 'font-bold italic text-foreground'
+          } ${isLandscape ? 'pt-10 sm:text-4xl' : 'sm:text-5xl'} lg:text-7xl`}
       >
         {text}
       </motion.p>

--- a/apps/next/src/components/sessions/SessionsUI.tsx
+++ b/apps/next/src/components/sessions/SessionsUI.tsx
@@ -56,13 +56,12 @@ export default function SessionsUI() {
                   className={cn(
                     `${isLandscape ? 'h-6 w-6' : 'h-12 w-12'} flex-1 rounded-lg border-2 transition-all duration-300 lg:h-14 lg:w-14`,
                     // 'border-gray-300 dark:border-white/80', // Light mode: black, Dark mode: white
-                    'border-[#B0B0B0] dark:border-white/50', // Light mode: black, Dark mode: white
-                    index <= currentSession - 1 // Completed work sessions
+                    'border-foreground/15 dark:border-foreground/25',
+                    index <= currentSession - 1
                       ? isWorking && currentSession - 1 === index
-                        ? // ? `${opacityClass}`
-                        'bg-pink-500'
-                        : 'bg-green-500'
-                      : '', // No color if not completed
+                        ? 'bg-foreground border-foreground shadow-[0_0_0_4px_hsl(var(--foreground)/0.12)]'
+                        : 'bg-foreground/55 border-foreground/55'
+                      : '',
                   )}
                 />
               ))}
@@ -74,12 +73,11 @@ export default function SessionsUI() {
                   className={cn(
                     `${isLandscape ? 'h-6 w-6' : 'h-12 w-12'} flex-1 rounded-lg border-2 transition-all duration-300 lg:h-14 lg:w-14`,
                     // 'border-gray-300 dark:border-white/80', // Light mode: black, Dark mode: white
-                    'border-[#B0B0B0] dark:border-white/50', // Light mode: black, Dark mode: white
-                    index < currentSession - 1 // Completed break sessions
-                      ? 'bg-green-500'
-                      : !isWorking && currentSession - 1 === index // Current break session
-                        ? // ? `${opacityClassBrk}`
-                        'bg-pink-500'
+                    'border-foreground/15 dark:border-foreground/25',
+                    index < currentSession - 1
+                      ? 'bg-foreground/55 border-foreground/55'
+                      : !isWorking && currentSession - 1 === index
+                        ? 'bg-foreground border-foreground shadow-[0_0_0_4px_hsl(var(--foreground)/0.12)]'
                         : 'bg-transparent',
                   )}
                 />
@@ -104,11 +102,11 @@ export default function SessionsUI() {
                 className={cn(
                   'aspect-square rounded-lg border-2 transition-all duration-300',
                   // 'border-gray-300 dark:border-white/80',
-                  'border-[#B0B0B0] dark:border-white/50', // Light mode: black, Dark mode: white
+                  'border-foreground/15 dark:border-foreground/25',
                   index <= currentSession - 1
                     ? isWorking && currentSession - 1 === index
-                      ? 'bg-pink-500'
-                      : 'bg-green-500'
+                      ? 'bg-foreground border-foreground shadow-[0_0_0_4px_hsl(var(--foreground)/0.12)]'
+                      : 'bg-foreground/55 border-foreground/55'
                     : '',
                 )}
               />
@@ -128,11 +126,11 @@ export default function SessionsUI() {
                 className={cn(
                   'aspect-square rounded-lg border-2 transition-all duration-300',
                   // 'border-gray-300 dark:border-white/80',
-                  'border-[#B0B0B0] dark:border-white/50', // Light mode: black, Dark mode: white
+                  'border-foreground/15 dark:border-foreground/25',
                   index < currentSession - 1
-                    ? 'bg-green-500'
+                    ? 'bg-foreground/55 border-foreground/55'
                     : !isWorking && currentSession - 1 === index
-                      ? 'bg-pink-500'
+                      ? 'bg-foreground border-foreground shadow-[0_0_0_4px_hsl(var(--foreground)/0.12)]'
                       : 'bg-transparent',
                 )}
               />

--- a/apps/next/src/components/timer/Timer.tsx
+++ b/apps/next/src/components/timer/Timer.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useSoundsStore } from '~/store/useSoundsStore'
 import { useTimerStore } from '~/store/useTimerStore'
+import TimerProgressRing from '../dashboard/TimerProgressRing'
 import useIsLandscape from '../helper/useIsMobileLandscape'
 import TimerUI from './TimeUI'
 
@@ -113,6 +114,7 @@ export default function Timer() {
 
   return (
     <div className='relative z-0 flex h-[70vh] items-center justify-center'>
+      <TimerProgressRing />
       <div className='absolute hidden h-[70vh] items-center justify-center font-bold sm:flex'>
         <TimerUI value={minutes} fontSize={isLandscape ? '30vh' : widthSize} />
         <p className={`flex h-full items-center ${isLandscape ? 'text-[30vh]' : textSize}`}>:</p>

--- a/apps/next/src/components/timer/TimerButtons.tsx
+++ b/apps/next/src/components/timer/TimerButtons.tsx
@@ -28,7 +28,7 @@ export default function TimerButtons() {
   const buttonVariant = isSmallScreen ? 'ghost' : 'outline'
 
   return (
-    <div className='flex items-center justify-center space-x-1'>
+    <div className='flex items-center justify-center gap-1 rounded-full bg-card/50 px-2 py-1.5 backdrop-blur-md shadow-[0_20px_60px_-30px_rgba(0,0,0,0.5)]'>
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger asChild>

--- a/packages/api/src/lib/middlewares/auth/create-better-auth-config.ts
+++ b/packages/api/src/lib/middlewares/auth/create-better-auth-config.ts
@@ -29,7 +29,7 @@ export function createBetterAuthConfig(dbInstance: any, c: Context<AppContext>) 
     return acc
   }, {})
 
-  const isProduction = env(c).env === 'production'
+  const isProduction = env(c).ENV === 'production'
 
   return {
     baseURL: env(c).API_DOMAIN, // API URL
@@ -43,12 +43,12 @@ export function createBetterAuthConfig(dbInstance: any, c: Context<AppContext>) 
     socialProviders: configuredProviders,
     advanced: {
       crossSubDomainCookies: {
-        enabled: true, // Enables cross-domain cookies
+        enabled: isProduction,
       },
       defaultCookieAttributes: {
-        sameSite: isProduction ? 'lax' : 'none',
-        secure: true,
-        domain: isProduction ? extractDomain(env(c).WEB_DOMAIN) : undefined, // Use env var for frontend domain
+        sameSite: 'lax',
+        secure: isProduction,
+        domain: isProduction ? extractDomain(env(c).WEB_DOMAIN) : undefined,
       },
     },
     rateLimit: {

--- a/packages/api/src/lib/middlewares/auth/initialize-better-auth.ts
+++ b/packages/api/src/lib/middlewares/auth/initialize-better-auth.ts
@@ -25,12 +25,12 @@ export const initializeBetterAuth = (c: Context<AppContext>) => {
     ...betterAuthConfig,
     advanced: {
       crossSubDomainCookies: {
-        enabled: true, // Enables cross-domain cookies
+        enabled: isProduction,
       },
       defaultCookieAttributes: {
-        sameSite: isProduction ? 'lax' : 'none',
-        secure: true,
-        domain: isProduction ? extractDomain(env(c).WEB_DOMAIN) : undefined, // Use env var for frontend domain
+        sameSite: 'lax',
+        secure: isProduction,
+        domain: isProduction ? extractDomain(env(c).WEB_DOMAIN) : undefined,
       },
     },
     plugins: [bearer()],

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -2,6 +2,20 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --font-app: 'Inter Tight', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-display: 'Inter Tight', ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --font-mono: 'Inter Tight', ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  /* Background customization contract — settings page writes to these */
+  --bg-image: none;
+  --bg-image-size: cover;
+  --bg-image-position: center;
+  --bg-overlay-color: 0 0% 0%;
+  --bg-overlay-opacity: 0;
+  --bg-blur: 0px;
+}
+
 ::-webkit-scrollbar {
   width: 8px;
 }
@@ -90,6 +104,7 @@
   }
   body {
     @apply bg-background text-foreground;
+    font-family: var(--font-app);
     /* @apply transition-colors duration-500 ease-in-out; */
     @apply transition-colors duration-500 ease-in-out;
   }

--- a/packages/ui/tailwind.config.ts
+++ b/packages/ui/tailwind.config.ts
@@ -20,6 +20,11 @@ const config = {
       },
     },
     extend: {
+      fontFamily: {
+        sans: ['var(--font-app)', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        display: ['var(--font-display)', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        mono: ['var(--font-mono)', 'ui-monospace', 'SFMono-Regular', 'Menlo', 'monospace'],
+      },
       colors: {
         border: 'hsl(var(--border))',
         input: 'hsl(var(--input))',


### PR DESCRIPTION
Refresh sign-in and dashboard with a shared visual system, and fix local OAuth.

  - Redesign /sign-in as a quiet, editorial layout with provider rows
    (GitHub, Google, Discord, Apple) and a "Continue as guest" escape hatch.
  - Swap inline serif font styles for Inter Tight, exposed via CSS vars
    (--font-app / --font-display / --font-mono) and wired through Tailwind.
  - Extract the sign-in aesthetic into shared dashboard components:
    AppBackground (driven by CSS vars, ready for a future settings UI)
    and TimerProgressRing (animated ring around the timer digits).
  - Polish the timer surface: glass-pill controls, bold-italic session
    title, "Paused" now shows for both paused work and paused break,
    and monochrome session pips replace the pink/green ones.
  - Fix local OAuth: read ENV (uppercase) for production detection, and
    only enable Secure cookies / cross-subdomain cookies in production —
    browsers were silently dropping the better-auth state cookie over
    http://localhost, breaking the OAuth round-trip in dev.
